### PR TITLE
Fix incorrect URLs when running from Windows

### DIFF
--- a/vagrant_metadata.py
+++ b/vagrant_metadata.py
@@ -67,7 +67,7 @@ def process_directory(root, metadata, force=False):
                 provider_data["checksum"] = compute_sha1(box)
                 provider_data["url"] = "%s/%s" % (
                     metadata["baseurl"],
-                    os.path.relpath(box, root),
+                    "/".join(os.path.relpath(box, root).split(os.sep))
                 )
 
             version_ret["providers"].append(provider_data)


### PR DESCRIPTION
This is a small change to the way the URL for each version is generated - instead of just appending the relative path to the base URL, it will now translate the OS path component separator (whether you're on POSIX and it's `'/'` or Windows where it's `'\\'`) into URL-appropriate forward slashes (`'/'`). 